### PR TITLE
dotnet 3.1 update and FH4 CarDash

### DIFF
--- a/Console/ForzaData.Console.csproj
+++ b/Console/ForzaData.Console.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>netcoreapp2.2</TargetFramework>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<Version>0.5</Version>
 		<Authors>Geoffrey Vancoetsem</Authors>
 		<Company></Company>

--- a/Console/ForzaDataConsole.cs
+++ b/Console/ForzaDataConsole.cs
@@ -83,6 +83,7 @@ namespace ForzaData.Console
 
 			lock (SyncRoot)
 			{
+
 				// line 1
 				ConsoleWriteAt(5, 0, GetRaceIsOneValue(sd.IsRaceOn), 3, GetRaceIsOneValueColor(sd.IsRaceOn));
 				ConsoleWriteAt(13, 0, $"{sd.CarOrdinal,11:##0}", 11);
@@ -116,35 +117,33 @@ namespace ForzaData.Console
 				ConsoleWriteAt(25, 13, $"{sd.AngularVelocityY,11:###0.000000}", 11);
 				ConsoleWriteAt(37, 13, $"{sd.AngularVelocityZ,11:###0.000000}", 11);
 
-				if (data.CarDash.HasValue)
-				{
-					ForzaCarDashDataStruct cdd = data.CarDash.Value;
+				
+				ForzaCarDashDataStruct cdd = data.CarDash;
 
-					// line 2
-					ConsoleWriteAt(4, 1, $"{cdd.LapNumber + 1}", 3);
-					ConsoleWriteAt(17, 1, $"{cdd.RacePosition}", 2);
-					ConsoleWriteAt(25, 1, $"{cdd.Fuel * 100f,5:##0.0}", 5);
-					ConsoleWriteAt(42, 1, $"{cdd.DistanceTraveled / 1000f,5:##0.0}", 5);
-					ConsoleWriteAt(56, 1, GetRaceTimeValue(cdd.CurrentRaceTime), 14);
+				// line 2
+				ConsoleWriteAt(4, 1, $"{cdd.LapNumber + 1}", 3);
+				ConsoleWriteAt(17, 1, $"{cdd.RacePosition}", 2);
+				ConsoleWriteAt(25, 1, $"{cdd.Fuel * 100f,5:##0.0}", 5);
+				ConsoleWriteAt(42, 1, $"{cdd.DistanceTraveled / 1000f,5:##0.0}", 5);
+				ConsoleWriteAt(56, 1, GetRaceTimeValue(cdd.CurrentRaceTime), 14);
 
-					// speed, power, torque
-					ConsoleWriteAt(27, 3, $"{cdd.Speed * 3.6f,7:####0.0}", 7);
-					ConsoleWriteAt(27, 4, $"{cdd.Power / 1000f,7:####0.0}", 7);
-					ConsoleWriteAt(27, 5, $"{cdd.Torque,7:####0.0}", 7);
+				// speed, power, torque
+				ConsoleWriteAt(27, 3, $"{cdd.Speed * 3.6f,7:####0.0}", 7);
+				ConsoleWriteAt(27, 4, $"{cdd.Power / 1000f,7:####0.0}", 7);
+				ConsoleWriteAt(27, 5, $"{cdd.Torque,7:####0.0}", 7);
 
-					// laps
-					ConsoleWriteAt(50, 3, GetRaceTimeValue(cdd.CurrentLap), 14);
-					ConsoleWriteAt(50, 4, GetRaceTimeValue(cdd.LastLap), 14);
-					ConsoleWriteAt(50, 5, GetRaceTimeValue(cdd.BestLap), 14);
+				// laps
+				ConsoleWriteAt(50, 3, GetRaceTimeValue(cdd.CurrentLap), 14);
+				ConsoleWriteAt(50, 4, GetRaceTimeValue(cdd.LastLap), 14);
+				ConsoleWriteAt(50, 5, GetRaceTimeValue(cdd.BestLap), 14);
 
-					// controls
-					ConsoleWriteAt(63, 7, $"{cdd.Accel / 2.55f,3:##0}", 3);
-					ConsoleWriteAt(63, 8, $"{cdd.Brake / 2.55f,3:##0}", 3);
-					ConsoleWriteAt(63, 9, $"{cdd.Clutch / 2.55f,3:##0}", 3);
-					ConsoleWriteAt(63, 10, $"{cdd.HandBrake / 2.55f,3:##0}", 3);
-					ConsoleWriteAt(63, 11, $"{cdd.Gear,3:##0}", 3);
-					ConsoleWriteAt(62, 12, $"{cdd.Steer / 1.27f,3:+0;-0;0}", 4); 
-				}
+				// controls
+				ConsoleWriteAt(63, 7, $"{cdd.Accel / 2.55f,3:##0}", 3);
+				ConsoleWriteAt(63, 8, $"{cdd.Brake / 2.55f,3:##0}", 3);
+				ConsoleWriteAt(63, 9, $"{cdd.Clutch / 2.55f,3:##0}", 3);
+				ConsoleWriteAt(63, 10, $"{cdd.HandBrake / 2.55f,3:##0}", 3);
+				ConsoleWriteAt(63, 11, $"{cdd.Gear,3:##0}", 3);
+				ConsoleWriteAt(62, 12, $"{cdd.Steer / 1.27f,3:+0;-0;0}", 4);
 			}
 		}
 

--- a/Console/Properties/launchSettings.json
+++ b/Console/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ForzaData.Console": {
       "commandName": "Project",
-      "commandLineArgs": "-ServerIpAddress 192.168.0.10 -Port 7777"
+      "commandLineArgs": "-ServerIpAddress 127.0.0.1 -Port 12000"
     }
   }
 }

--- a/Core/ForzaData.Core.csproj
+++ b/Core/ForzaData.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<Version>0.5</Version>
 		<Authors>Geoffrey Vancoetsem</Authors>
 		<Company></Company>

--- a/Core/ForzaDataStruct.cs
+++ b/Core/ForzaDataStruct.cs
@@ -22,11 +22,16 @@ namespace ForzaData.Core
 		/// <summary>
 		/// Car dash data
 		/// </summary>
-		public ForzaCarDashDataStruct? CarDash;
+		public ForzaCarDashDataStruct CarDash;
 
 		/// <summary>
-		/// Horizon specific car dash data
+		/// Horizon specific data part 1
 		/// </summary>
-		public byte[] HorizonCarDash;
+		public byte[] HorizonData1;
+
+		/// <summary>
+		/// Horizon specific data part 2
+		/// </summary>
+		public byte[] HorizonData2;
 	}
 }

--- a/ForzaDataWeb.sln
+++ b/ForzaDataWeb.sln
@@ -3,21 +3,21 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28729.10
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ForzaData.Web", "Web\ForzaData.Web.csproj", "{E97262A1-C8CE-45A6-9F6E-DA4D07DD765D}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ForzaData.Tests", "Tests\ForzaData.Tests.csproj", "{7A2718F7-7DA3-4015-85D2-E2244F71CE5A}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ForzaData.Console", "Console\ForzaData.Console.csproj", "{5B142436-5225-4461-9CDD-04C885200230}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ForzaData.Core", "Core\ForzaData.Core.csproj", "{15424D1D-BB5E-417A-A8E0-4F97340B1ADC}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9EDFB982-DFDF-4E51-9C77-0D34A23B0AF8}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ForzaData.SampleRecorder", "SampleRecorder\ForzaData.SampleRecorder.csproj", "{E98526DE-487B-4DC9-B523-AC5EC2770F8C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ForzaData.Core", "Core\ForzaData.Core.csproj", "{5DA393E3-E440-4F22-B7E6-DA00312DADCC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ForzaData.Console", "Console\ForzaData.Console.csproj", "{00514889-1FFE-43FF-A275-EE5172703565}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ForzaData.SampleRecorder", "SampleRecorder\ForzaData.SampleRecorder.csproj", "{68DA83E1-A8D7-41B7-9F1C-E4601C230E57}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ForzaData.Tests", "Tests\ForzaData.Tests.csproj", "{A06E9305-4DB6-4908-862D-68A8A619D609}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ForzaData.Web", "Web\ForzaData.Web.csproj", "{BB30DF07-0E8B-434C-B10E-47314B0E72D2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -25,26 +25,26 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E97262A1-C8CE-45A6-9F6E-DA4D07DD765D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E97262A1-C8CE-45A6-9F6E-DA4D07DD765D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E97262A1-C8CE-45A6-9F6E-DA4D07DD765D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E97262A1-C8CE-45A6-9F6E-DA4D07DD765D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7A2718F7-7DA3-4015-85D2-E2244F71CE5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7A2718F7-7DA3-4015-85D2-E2244F71CE5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7A2718F7-7DA3-4015-85D2-E2244F71CE5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7A2718F7-7DA3-4015-85D2-E2244F71CE5A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5B142436-5225-4461-9CDD-04C885200230}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5B142436-5225-4461-9CDD-04C885200230}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5B142436-5225-4461-9CDD-04C885200230}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5B142436-5225-4461-9CDD-04C885200230}.Release|Any CPU.Build.0 = Release|Any CPU
-		{15424D1D-BB5E-417A-A8E0-4F97340B1ADC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{15424D1D-BB5E-417A-A8E0-4F97340B1ADC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{15424D1D-BB5E-417A-A8E0-4F97340B1ADC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{15424D1D-BB5E-417A-A8E0-4F97340B1ADC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E98526DE-487B-4DC9-B523-AC5EC2770F8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E98526DE-487B-4DC9-B523-AC5EC2770F8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E98526DE-487B-4DC9-B523-AC5EC2770F8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E98526DE-487B-4DC9-B523-AC5EC2770F8C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5DA393E3-E440-4F22-B7E6-DA00312DADCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5DA393E3-E440-4F22-B7E6-DA00312DADCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5DA393E3-E440-4F22-B7E6-DA00312DADCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DA393E3-E440-4F22-B7E6-DA00312DADCC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00514889-1FFE-43FF-A275-EE5172703565}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00514889-1FFE-43FF-A275-EE5172703565}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00514889-1FFE-43FF-A275-EE5172703565}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00514889-1FFE-43FF-A275-EE5172703565}.Release|Any CPU.Build.0 = Release|Any CPU
+		{68DA83E1-A8D7-41B7-9F1C-E4601C230E57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{68DA83E1-A8D7-41B7-9F1C-E4601C230E57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{68DA83E1-A8D7-41B7-9F1C-E4601C230E57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{68DA83E1-A8D7-41B7-9F1C-E4601C230E57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A06E9305-4DB6-4908-862D-68A8A619D609}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A06E9305-4DB6-4908-862D-68A8A619D609}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A06E9305-4DB6-4908-862D-68A8A619D609}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A06E9305-4DB6-4908-862D-68A8A619D609}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB30DF07-0E8B-434C-B10E-47314B0E72D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB30DF07-0E8B-434C-B10E-47314B0E72D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB30DF07-0E8B-434C-B10E-47314B0E72D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB30DF07-0E8B-434C-B10E-47314B0E72D2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ No Web interface for the moment.
 | Game               | Sled     | Car Dash | _Horizon_ |
 |--------------------|----------|----------|-----------|
 | Forza Motorsport 7 | Yes      | Yes      | N/A       |
-| Forza Horizon 4    | Yes      | No       | No        |
+| Forza Horizon 4    | Yes      | Yes      | No        |
 
-_Note_ : Forza Horizon 4 is actually using an undocumented protocol. Only the Sled part of it can be read.
+_Note_ : Forza Horizon 4 is actually using an undocumented protocol. Car Dash data has been found however there are 2 undocumented FH4 sections which are now added
 
 ## How to test
 

--- a/SampleRecorder/ForzaData.SampleRecorder.csproj
+++ b/SampleRecorder/ForzaData.SampleRecorder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 		<Version>0.5</Version>
 		<Authors>Geoffrey Vancoetsem</Authors>
 		<Company></Company>

--- a/Tests/ForzaData.Tests.csproj
+++ b/Tests/ForzaData.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp2.2</TargetFramework>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<Version>0.5</Version>
 		<Authors>Geoffrey Vancoetsem</Authors>

--- a/Web/Configuration/AppSettings.cs
+++ b/Web/Configuration/AppSettings.cs
@@ -9,7 +9,7 @@ namespace Receiver.Configuration
     {
 		public AppSettings()
 		{
-			UdpPort = 7777;
+			UdpPort = 12000;
 		}
 
 		public int UdpPort { get; set; }

--- a/Web/ForzaData.Web.csproj
+++ b/Web/ForzaData.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp2.2</TargetFramework>
+		<TargetFramework>netcoreapp3.1</TargetFramework>
 		<Version>0.5</Version>
 		<Authors>Geoffrey Vancoetsem</Authors>
 		<Company></Company>
@@ -11,10 +11,6 @@
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.App" />
-	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Core\ForzaData.Core.csproj" />

--- a/Web/Startup.cs
+++ b/Web/Startup.cs
@@ -35,7 +35,7 @@ namespace Receiver
 
 			services.AddSingleton<ForzaDataListener>();
 
-			services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+			services.AddControllersWithViews();
 		}
 
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -54,11 +54,15 @@ namespace Receiver
 			app.UseStaticFiles();
 			app.UseCookiePolicy();
 
-			app.UseMvc(routes =>
+			app.UseRouting();
+
+			//app.UseAuthorization();
+
+			app.UseEndpoints(endpoints =>
 			{
-				routes.MapRoute(
+				endpoints.MapControllerRoute(
 					name: "default",
-					template: "{controller=Home}/{action=Index}/{id?}");
+					pattern: "{controller=Home}/{action=Index}/{id?}");
 			});
 		}
 	}

--- a/Web/appsettings.json
+++ b/Web/appsettings.json
@@ -6,6 +6,6 @@
 	},
 	"AllowedHosts": "*",
 	"App": {
-		"UdpPort": 5777
+		"UdpPort": 12000
 	}
 }


### PR DESCRIPTION
Updates to dotnet core 3.1 as 2.2 is EOL

Although undocumented the FH4 Car Dash data is set at 12 bytes away from the standard sled data. These 12 bytes seem to be some car info and scene damage indication. 

I created a HorizonData1 and HorizonData2 section to account for the two sections of FH4 data and just loaded the CarDashData into the original object and made it not nullable.

